### PR TITLE
🐛 changed exp after message and groq history limit

### DIFF
--- a/app/bot.py
+++ b/app/bot.py
@@ -3,7 +3,7 @@ from discord.ext import commands
 from app.config import Config
 import os
 from app.utils.logger import logger
-
+from app.discord_games.tic_tac_toe.tic_tac_toe import start_tic_tac_toc
 intents = discord.Intents.default()
 intents.message_content = True
 intents.members = True
@@ -12,12 +12,15 @@ intents.guilds = True
 intents.presences = True  # Enable the presences intent
 
 bot = commands.Bot(command_prefix=Config.PREFIX, intents=intents)
+bot.bot_id = None  # Initialize bot_id
 
 @bot.event
 async def on_ready():
     logger.info("------")
     logger.info("Cooler AI-Chan is Up and ready!")
     
+    bot.bot_id = bot.user.id  # Set bot's user ID
+    logger.info(f"Bot ID is {bot.bot_id}")
 
     try:
         await bot.tree.sync(guild=discord.Object(id=Config.GUILD_ID))
@@ -53,6 +56,14 @@ async def main():
     async with bot:
         await load_cogs()
         await bot.start(Config.DISCORD_TOKEN)
+
+@bot.tree.command(name="tic_tac_toe")
+async def tic_tac_toe(interaction: discord.Interaction, difficulty: str):
+    bot.loop.create_task(start_tic_tac_toc(interaction, difficulty))
+
+@bot.tree.command(name="ping", description="Ping the bot")
+async def ping(interaction: discord.Interaction):
+    await interaction.response.send_message("Pong!")
 
 if __name__ == "__main__":
     import asyncio

--- a/app/cogs/command_handling_service_cog.py
+++ b/app/cogs/command_handling_service_cog.py
@@ -74,7 +74,7 @@ class CommandHandlingService(commands.Cog):
     async def on_message(self, message):
         if message.author.bot:
             return
-        
+
         # Check if the message is a command
         if message.content.startswith(Config.PREFIX):
             return
@@ -100,11 +100,13 @@ class CommandHandlingService(commands.Cog):
 
         # Level up for chatting
         if os.path.exists(self.database.path):
-            if self.previous_author != message.author.id:
+            if self.previous_author not in [message.author.id, self.bot.bot_id]:
                 level_up, _ = self.database.add_exp(message.author.id, 1)
                 if level_up:
                     await message.channel.send(f"🎉 Level Up! 🎉 Congratulations! {message.author.mention}! You leveled up from babbling so much!")
             self.previous_author = message.author.id
+
+
 
         # Bad word filter
         if 'badword' in message.content:

--- a/app/utils/ai_related/groq_service.py
+++ b/app/utils/ai_related/groq_service.py
@@ -21,7 +21,7 @@ class GroqService:
     async def assemble_chat_history(self, context, user_message):
         try:
             logger.info(f"Question: {user_message}")
-            messages = [message async for message in context.channel.history(limit=50)]
+            messages = [message async for message in context.channel.history(limit=30)]
             #logger.debug(f"Fetched messages: {[message.content for message in messages]}")
 
             chat_messages = []


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request introduces new commands for playing Tic Tac Toe and pinging the bot, fixes a bug related to experience point allocation, and optimizes chat history retrieval by reducing the message limit.

* **New Features**:
    - Introduced a new 'tic_tac_toe' command to start a Tic Tac Toe game with specified difficulty.
    - Added a 'ping' command to check the bot's responsiveness.
* **Bug Fixes**:
    - Fixed an issue where the bot would incorrectly add experience points to itself by excluding the bot's ID from the experience gain check.
* **Enhancements**:
    - Reduced the chat history limit from 50 to 30 messages in the 'assemble_chat_history' function to optimize performance.

<!-- Generated by sourcery-ai[bot]: end summary -->