### PR TITLE
🛠️ Refactor alarm limit to 365 days and adjust GPT temperature

### DIFF
--- a/app/cogs/ai_commands_cog.py
+++ b/app/cogs/ai_commands_cog.py
@@ -84,7 +84,7 @@ class AICommands(commands.Cog):
             
 
 
-    @custom_command(name='oldask', help="Ask a question to the AI.")
+    @commands.hybrid_command(name='oldask', help="Ask a question to the AI.")
     async def oldask(self, ctx, *, question):
         try:
             logger.debug(f"------- \nCommand ASK used by user {ctx.author.name}")
@@ -98,7 +98,7 @@ class AICommands(commands.Cog):
         
     
 
-    @custom_command(name='oldchat', help="Chat with the AI.")
+    @commands.hybrid_command(name='oldchat', help="Chat with the AI.")
     async def oldchat(self, ctx, *, question: str):
         try:
             logger.debug(f"------- \nCommand CHAT used by user {ctx.author.name}")
@@ -115,7 +115,7 @@ class AICommands(commands.Cog):
             logger.error(f"Error in Chat command: {ex}")
             await ctx.send("Sorry, something went wrong while processing your request.")
 
-    @custom_command(name='vision', help="Ask a question to the AI with an image.")
+    @commands.hybrid_command(name='vision', help="Ask a question to the AI with an image.")
     async def vision(self, ctx, question: str, attachment: discord.Attachment = None):
         try:
             logger.debug(f"------- \nCommand VISION used by user {ctx.author.name}")

--- a/app/cogs/alarm_cog.py
+++ b/app/cogs/alarm_cog.py
@@ -44,8 +44,8 @@ class AlarmCog(commands.Cog):
 
         try:
             seconds = self.parse_time(time_str)
-            if seconds is None or seconds > 2592000:  # Limit to 30 days (30 * 86400)
-                await ctx.send("Please use a valid time format (e.g., 5m, 10s, 1h 30m 10s, 7d) and within 30 days.")
+            if seconds is None or seconds > 31536000:  # Limit to 365 days (365 * 86400)
+                await ctx.send("Please use a valid time format (e.g., 5m, 10s, 1h 30m 10s, 7d) and within 365 days.")
                 return
 
             trigger_time = int(time.time()) + seconds
@@ -127,11 +127,6 @@ class AlarmCog(commands.Cog):
                 del self.alarms[alarm_id]
         self.database.delete_user_alarms(user_id)
         await ctx.send(f"All alarms have been cancelled, {ctx.message.author.mention}.")
-
-
-    
-       
-
 
     async def start_alarm(self, ctx, trigger_time, note):
         await asyncio.sleep(max(0, trigger_time - int(time.time())))

--- a/app/cogs/managment_module_cog.py
+++ b/app/cogs/managment_module_cog.py
@@ -13,11 +13,12 @@ class ManagementModule(commands.Cog):
         self.database = DatabaseService()
         self.shiro_id = Config.master_user_id
         self.nequs_id = Config.nequs_id
+        
     @commands.command(name='ban', aliases=['kick', 'exile'], help='Bans, kicks, or exiles someone! Use +ban @user, +kick @user, or +exile @user')
     @commands.guild_only()
     @commands.has_permissions(kick_members=True, ban_members=True)
     @commands.bot_has_permissions(kick_members=True, ban_members=True)
-    async def handle_member(self, ctx: Context, *, command: str):
+    async def handle_member(self, ctx: commands.Context, *, command: str):
         try:
             user = await commands.MemberConverter().convert(ctx, command)
         except commands.MemberNotFound:
@@ -25,18 +26,17 @@ class ManagementModule(commands.Cog):
             return
 
         if user.id == self.shiro_id:
-            await ctx.send("You cannot take action against Shiro the god!")
-            return
-        elif user.id == self.nequs_id:
-            await ctx.send("Nequs, you wish but I'm the Ai-chan owner!")
+            if ctx.author.id == self.nequs_id:
+                await ctx.send("Nequs, you wish but I'm the Ai-chan owner!")
+            else:
+                await ctx.send("You cannot take action against Shiro the god!")
             return
 
-        if ctx.invoked_with == 'ban':
+        # Nequs-specific check removed, allowing Nequs to ban others
+        if ctx.invoked_with in ['ban', 'exile', 'kick']:
             await user.ban(reason=None)
             await ctx.send(f"{user.name}#{user.discriminator} has been banned!")
-        else:
-            await user.kick(reason=None)
-            await ctx.send(f"{user.name}#{user.discriminator} has been exiled!")
+        
     
 
     @custom_command(name='clear', help='Deletes specified amount of messages. +clear number')

--- a/app/cogs/whiteneko_stuff_cog.py
+++ b/app/cogs/whiteneko_stuff_cog.py
@@ -57,7 +57,9 @@ class WhitenekoModule(commands.Cog):
         """
         await ctx.message.delete()
         await user.send(text)
-
+        
+    @commands.guild_only()
+    @commands.has_permissions(kick_members=True, ban_members=True)
     @commands.command(name='operation')
     async def operation(self, ctx, user: discord.Member):
         """Counts down and kicks a specified user from the server.

--- a/app/utils/ai_related/chatgpt_api.py
+++ b/app/utils/ai_related/chatgpt_api.py
@@ -55,7 +55,7 @@ async def ask_gpt(author, author_id, user_message):
         return "Sorry, something went wrong while processing your request."
 
 async def send_to_openai_gpt(messages):
-    completion = await asyncio.to_thread(client.chat.completions.create, model="gpt-4o", messages=messages, temperature=1.3)
+    completion = await asyncio.to_thread(client.chat.completions.create, model="gpt-4o", messages=messages, temperature=0.7)
     answer = completion.choices[0].message.content
     prompt_tokens = completion.usage.prompt_tokens
     completion_tokens = completion.usage.completion_tokens


### PR DESCRIPTION
- Refactor AlarmCog to limit alarms to 365 days instead of 30 days. Also adjust
  GPT API temperature to 0.7 for better responses.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request extends the alarm limit to 365 days, adjusts the GPT API temperature to 0.7, and refactors command handling in ManagementModuleCog to remove a Nequs-specific check.

- **Enhancements**:
    - Extended the alarm limit in AlarmCog from 30 days to 365 days.
    - Adjusted the GPT API temperature setting to 0.7 for improved response quality.
    - Refactored command handling in ManagementModuleCog to remove Nequs-specific check, allowing Nequs to ban others.

<!-- Generated by sourcery-ai[bot]: end summary -->