### PR TITLE
✨ Add tea timer feature

### DIFF
--- a/app/cogs/tea_timer_cog.py
+++ b/app/cogs/tea_timer_cog.py
@@ -1,0 +1,108 @@
+import discord
+from discord.ext import commands
+import asyncio
+
+class TeaTimerCog(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+        self.tea_timers = {}  # {user_id: (timer, end_time)}
+        self.default_times = {}  # {user_id: default_time_in_seconds}
+
+    def parse_time(self, time_str):
+        # Replace ',' or '.' with ':' for uniform handling
+        time_str = time_str.replace(',', ':').replace('.', ':')
+
+        # Handle different time formats
+        if ':' in time_str:
+            parts = time_str.split(':')
+            if len(parts) == 2:
+                minutes, seconds = map(int, parts)
+            else:
+                raise ValueError("Invalid time format")
+        else:
+            minutes, seconds = int(time_str), 0
+
+        # Adjust time if seconds > 59
+        if seconds > 59:
+            minutes += 1
+            seconds = 0
+
+        # Limit to 59:59
+        minutes = min(minutes, 59)
+
+        return int(minutes * 60 + seconds)
+
+    @commands.hybrid_command(name='tea', help="Start a tea timer. Usage: /tea [time]")
+    async def tea(self, ctx, time_str: str = None):
+        user_id = ctx.author.id
+
+        if time_str is None:
+            if user_id in self.default_times:
+                seconds = self.default_times[user_id]
+            else:
+                await ctx.send("Please provide a time or set a default time with /settea.")
+                return
+        else:
+            try:
+                seconds = self.parse_time(time_str)
+            except ValueError:
+                await ctx.send("Invalid time format. Please use 'm:ss', 'm.ss', 'm,ss' or 'm'")
+                return
+
+        # Cancel existing timer if any
+        if user_id in self.tea_timers:
+            self.tea_timers[user_id][0].cancel()
+
+        # Start new timer
+        end_time = ctx.message.created_at.timestamp() + seconds
+        timer = asyncio.create_task(self.tea_timer(ctx, seconds))
+        self.tea_timers[user_id] = (timer, end_time)
+
+        await ctx.send(f"Tea timer set for {seconds // 60}:{seconds % 60:02d}.")
+
+    async def tea_timer(self, ctx, seconds):
+        await asyncio.sleep(seconds)
+        await ctx.send(f"{ctx.author.mention}, your tea is ready!")
+        del self.tea_timers[ctx.author.id]
+
+    @commands.hybrid_command(name='teahelp', help="Show current tea timer status")
+    async def teahelp(self, ctx):
+        user_id = ctx.author.id
+        embed = discord.Embed(title="Tea Timer Help", color=discord.Color.green())
+
+        if user_id in self.tea_timers:
+            _, end_time = self.tea_timers[user_id]
+            remaining = max(0, int(end_time - ctx.message.created_at.timestamp()))
+            embed.add_field(name="Current Timer", value=f"{remaining // 60}:{remaining % 60:02d}")
+        else:
+            embed.add_field(name="Current Timer", value="No active timer")
+
+        if user_id in self.default_times:
+            default = self.default_times[user_id]
+            embed.add_field(name="Default Time", value=f"{default // 60}:{default % 60:02d}")
+        else:
+            embed.add_field(name="Default Time", value="Not set")
+
+        await ctx.send(embed=embed)
+
+    @commands.hybrid_command(name='settea', help="Set default tea timer. Usage: /settea [time]")
+    async def settea(self, ctx, time_str: str):
+        try:
+            seconds = self.parse_time(time_str)
+            self.default_times[ctx.author.id] = seconds
+            await ctx.send(f"Default tea timer set to {seconds // 60}:{seconds % 60:02d}.")
+        except ValueError:
+            await ctx.send("Invalid time format. Please use 'm:ss', 'm.ss', or 'm'.")
+
+    @commands.hybrid_command(name='stoptea', help="Stop the current tea timer")
+    async def stoptea(self, ctx):
+        user_id = ctx.author.id
+        if user_id in self.tea_timers:
+            self.tea_timers[user_id][0].cancel()
+            del self.tea_timers[user_id]
+            await ctx.send("Tea timer stopped.")
+        else:
+            await ctx.send("No active tea timer to stop.")
+
+async def setup(bot):
+    await bot.add_cog(TeaTimerCog(bot))

--- a/app/utils/logger.py
+++ b/app/utils/logger.py
@@ -80,12 +80,12 @@ class CustomFileHandler(BaseRotatingHandler):
 def setup_logger():
     logger = logging.getLogger('discord_bot')
     logger.setLevel(logging.DEBUG)
+    logger.propagate = False  # Prevent propagation to root logger
 
     # Ensure the log directory exists
     log_dir = os.path.dirname(Config.LOG_FILE_PATH)
     if not os.path.exists(log_dir):
         os.makedirs(log_dir)
-        logging.debug(f"Created log directory: {log_dir}")
 
     # Custom File handler with utf-8 encoding
     file_handler = CustomFileHandler(Config.LOG_FILE_PATH, maxBytes=1024*1024*0.5, encoding='utf-8')
@@ -94,9 +94,9 @@ def setup_logger():
 
     # Stream handler (console) with color
     console_handler = colorlog.StreamHandler()
-    console_handler.setLevel(logging.DEBUG)
+    console_handler.setLevel(logging.INFO)  # Set console handler to INFO level
     console_handler.setFormatter(colorlog.ColoredFormatter(
-        '%(log_color)s%(levelname)s: %(message)s',
+        '%(log_color)s%(message)s',  # Remove levelname from console output
         log_colors={
             'DEBUG': 'green',
             'INFO': 'light_blue',
@@ -112,3 +112,9 @@ def setup_logger():
     return logger
 
 logger = setup_logger()
+
+# Disable logging for some noisy libraries
+logging.getLogger('discord').setLevel(logging.WARNING)
+logging.getLogger('discord.http').setLevel(logging.WARNING)
+logging.getLogger('websockets').setLevel(logging.WARNING)
+logging.getLogger('chardet').setLevel(logging.WARNING)


### PR DESCRIPTION
Add tea timer command with functionality to set, start, stop and display
timers for preparing tea. The TeaTimerCog class is introduced to handle
all tea timer logic. The timer is implemented using asyncio tasks. Set
and display default tea timer times as well.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add a tea timer feature with commands to manage tea preparation timers, including setting, starting, stopping, and displaying timers. Introduce the TeaTimerCog class to encapsulate the tea timer logic.

New Features:
- Introduce a tea timer feature with commands to set, start, stop, and display timers for preparing tea.

Enhancements:
- Add a new TeaTimerCog class to handle all tea timer logic using asyncio tasks.

<!-- Generated by sourcery-ai[bot]: end summary -->